### PR TITLE
Simple extension submit workflow

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,24 @@
+name: Submit Extension
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          cd whackamole
+          zip -r ../whackamole.zip .
+
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        with:
+          keys: ${{ secrets.SUBMIT_KEYS }}
+          artifact: whackamole.zip
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: whackamole.zip


### PR DESCRIPTION
Hi @laffra -

Love the simplicity of your extension! I was looking for ways to contribute, and thought adding a bit more ci might help. This PR introduces a new github action workflow that zip the whackamole directory, automatically submit the zip files to extension stores, then upload the artifact into a release (which will allow you to remove the zip from the repo and use the release page instead). 

The action is set to run manually from the github action tab, but we can tweak it to run as frequent as needed! The only thing you would need to create is a `SUBMIT_KEYS` github repository secret.

This secret is a json, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/main/keys.schema.json).

Here's a sample key for you:

```json
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/main/keys.schema.json",
  "chrome": {
    "clientId": "123",
    "refreshToken": "789",
    "extId": "abcd"
  }
}
```

You can find instructions on how to get the keys in the schema, or in this [doc](https://github.com/plasmo-corp/bms/blob/main/tokens.md). If you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me! Otherwise if this doesn't seem necessary, feel free to close the PR :)

---

Side notes: [bpp](https://browser.market) is an open source action, together with its dependencies. You can audit the source 
 as well as providing any issue/feedback here:
- [Browser Plugin Publisher](https://github.com/plasmo-corp/bpp)
- [Browser Market Submit](https://github.com/plasmo-corp/bms)
- [Mozilla Webstore Upload](https://github.com/plasmo-corp/mwu)
- [Chrome Webstore Upload](https://github.com/plasmo-corp/cwu)